### PR TITLE
Ensure deposit clicked before gather search

### DIFF
--- a/rok_bot/gem_farmer.py
+++ b/rok_bot/gem_farmer.py
@@ -383,6 +383,15 @@ def perform_full_gem_farming_cycle(initial_gem_location_box):
     for attempt in range(MAX_SUBSEQUENT_STEP_RETRIES):
         print(f"\nAttempt {attempt + 1} of {MAX_SUBSEQUENT_STEP_RETRIES} for subsequent steps (Gather, New Troop, March)...")
 
+        # Ensure the gem menu is open by clicking the deposit at the start of each attempt
+        click_at_location(
+            initial_gem_location_box,
+            "Re-Click Initial Gem at Attempt Start",
+            move_duration=0.3,
+            pre_click_pause=0.1,
+        )
+        time.sleep(RETRY_PAUSE_SECONDS / 2)
+
         gather_button_location_result = find_and_click( # Renamed to avoid conflict
             GATHER_TEMPLATE, CONFIDENCE_GATHER, "Gather Button",
             click_delay_after=CLICK_DELAY_MEDIUM, use_grayscale=True,


### PR DESCRIPTION
## Summary
- ensure the gem deposit is re-clicked at the start of every retry loop so the menu stays open

## Testing
- `python -m py_compile rok_bot/gem_farmer.py`

------
https://chatgpt.com/codex/tasks/task_e_6841b6dc8798832db673fd9530a00e5a