### PR TITLE
Handle deposit verification skip with zoom out

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Python script uses `pyautogui` to automate the process of finding and farmi
 *   Debug options, including taking screenshots on certain events (e.g., after initial click, if gather fails).
 *   Simple GUI to start and stop the bot.
 *   Automatically resizes the game window to **1280x720** when the bot starts.
-*   Can zoom out after sending a march by a configurable number of mouse wheel clicks.
+*   Can zoom out after sending a march, or when skipping an unavailable deposit, by a configurable number of mouse wheel clicks.
 
 ## Setup
 
@@ -55,9 +55,10 @@ Alternatively, launch the GUI:
     ```bash
     python rok_bot/gui.py
     ```
-    The GUI allows you to adjust the confidence level for detecting gem icons
-    and tweak how the bot moves across the map before starting. These values are
-    passed to the bot as command line arguments when you click **Start Bot**.
+    The GUI allows you to adjust the confidence level for detecting gem icons,
+    tweak how the bot moves across the map, and set how many mouse wheel clicks
+    the bot uses when zooming out. These values are passed to the bot as command
+    line arguments when you click **Start Bot**.
 3.  **Initial Countdown:** The script has a 5-second countdown before it starts interacting. Use this time to switch to the game window and ensure it's in focus.
 4.  **Stopping the Bot:**
     *   **Failsafe:** Quickly move your mouse cursor to one of the corners of your primary screen. This will trigger `pyautogui`'s failsafe mechanism and stop the script.

--- a/rok_bot/gem_farmer.py
+++ b/rok_bot/gem_farmer.py
@@ -422,6 +422,7 @@ def perform_full_gem_farming_cycle(initial_gem_location_box):
 
     if not verify_deposit_available():
         print("Deposit not available after verification. Skipping.")
+        zoom_out_after_dispatch()
         return False
 
     for attempt in range(MAX_SUBSEQUENT_STEP_RETRIES):


### PR DESCRIPTION
## Summary
- trigger zoom out when a deposit is skipped after verification
- document zoom control in the GUI section
- adjust feature list to mention zooming out on skipped deposits

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841cdd46914832dac182dec28c1c1b8