### PR TITLE
Add farming wait config to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ Alternatively, launch the GUI:
     python rok_bot/gui.py
     ```
     The GUI allows you to adjust the confidence level for detecting gem icons,
-    tweak how the bot moves across the map, and set how many mouse wheel clicks
-    the bot uses when zooming out. These values are passed to the bot as command
+    tweak how the bot moves across the map, set how many mouse wheel clicks
+    the bot uses when zooming out, and adjust how long the bot waits after
+    dispatching troops. These values are passed to the bot as command
     line arguments when you click **Start Bot**.
 3.  **Initial Countdown:** The script has a 5-second countdown before it starts interacting. Use this time to switch to the game window and ensure it's in focus.
 4.  **Stopping the Bot:**
@@ -69,7 +70,7 @@ Alternatively, launch the GUI:
 The main configuration variables are located at the top of the `rok_bot/gem_farmer.py` script. You can adjust:
 *   `CONFIDENCE_GEM`, `CONFIDENCE_GATHER`, `CONFIDENCE_GENERAL`: Confidence levels for image detection (0.0 to 1.0). Lower values may find more matches but can lead to false positives. Higher values require a closer match.
 *   `CLICK_DELAY_SHORT`, `CLICK_DELAY_MEDIUM`, `CLICK_DELAY_LONG`: Pauses after certain actions.
-*   `FARMING_DURATION_SECONDS`: How long to wait after successfully dispatching troops (default: 5 minutes).
+*   `FARMING_DURATION_SECONDS`: How long to wait after successfully dispatching troops (default: 5 minutes). This can also be set via the `--farming-duration` command line argument or in the GUI.
 *   `ORANGE_MARCH_BUTTON_TEMPLATE`: Path to the image for the special orange march button that might indicate a full farming queue (default: `images/orange_march_button.png`).
 *   `ORANGE_MARCH_WAIT_SECONDS`: Duration (in seconds) to wait if the orange march button is detected (default: `1800`, i.e., 30 minutes).
 *   `DEBUG_TAKE_SCREENSHOT_AFTER_FIRST_CLICK`, `DEBUG_TAKE_SCREENSHOT_IF_GATHER_FAILS`: Set to `True` or `False` to enable/disable debug screenshots. Screenshots are saved in the `rok_bot/debug_screenshots` directory.

--- a/rok_bot/gem_farmer.py
+++ b/rok_bot/gem_farmer.py
@@ -151,6 +151,12 @@ def parse_args():
         default=ZOOM_OUT_CLICKS_AFTER_MARCH,
         help="Mouse wheel clicks to zoom out after dispatching a march",
     )
+    parser.add_argument(
+        "--farming-duration",
+        type=int,
+        default=FARMING_DURATION_SECONDS,
+        help="Time in seconds to wait after sending a march",
+    )
     return parser.parse_args()
 
 
@@ -671,5 +677,6 @@ if __name__ == "__main__":
     SNAKE_SCANS_PER_HORIZONTAL_PASS = args.scans_per_pass
     SYSTEMATIC_SCAN_PAUSE_IF_NO_GEM = args.pause_no_gem
     ZOOM_OUT_CLICKS_AFTER_MARCH = args.zoom_out_clicks
+    FARMING_DURATION_SECONDS = args.farming_duration
 
     main_bot_loop()

--- a/rok_bot/gui.py
+++ b/rok_bot/gui.py
@@ -10,6 +10,7 @@ DEFAULT_SCROLL_DURATION = 2.0
 DEFAULT_SCANS_PER_PASS = 5
 DEFAULT_PAUSE_NO_GEM = 0.5
 DEFAULT_ZOOM_CLICKS = 0
+DEFAULT_FARMING_DURATION = 300
 
 bot_process = None
 log_file_position = 0
@@ -29,6 +30,7 @@ def start_bot():
                 '--scans-per-pass', str(scans_var.get()),
                 '--pause-no-gem', str(pause_var.get()),
                 '--zoom-out-clicks', str(zoom_var.get()),
+                '--farming-duration', str(farming_duration_var.get()),
             ])
             status_var.set('Bot running')
         except Exception as e:
@@ -90,6 +92,10 @@ ttk.Entry(options, textvariable=pause_var, width=6).grid(row=3, column=1, sticky
 ttk.Label(options, text='Zoom out clicks after march:').grid(row=4, column=0, sticky='w')
 zoom_var = tk.IntVar(value=DEFAULT_ZOOM_CLICKS)
 ttk.Entry(options, textvariable=zoom_var, width=6).grid(row=4, column=1, sticky='w')
+
+ttk.Label(options, text='Farming wait after dispatch (s):').grid(row=5, column=0, sticky='w')
+farming_duration_var = tk.IntVar(value=DEFAULT_FARMING_DURATION)
+ttk.Entry(options, textvariable=farming_duration_var, width=6).grid(row=5, column=1, sticky='w')
 
 start_button = ttk.Button(frame, text='Start Bot', command=start_bot)
 start_button.grid(row=0, column=0, padx=5, pady=5)


### PR DESCRIPTION
## Summary
- add `--farming-duration` CLI option
- expose farming wait time in GUI
- document new GUI feature and CLI option in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- *(failed: `python rok_bot/gem_farmer.py --help` due to missing display)*

------
https://chatgpt.com/codex/tasks/task_e_6841d020b618832d90df13b80431991b