### PR TITLE
Add configurable two-step zoom after march

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Python script uses `pyautogui` to automate the process of finding and farmi
 *   Debug options, including taking screenshots on certain events (e.g., after initial click, if gather fails).
 *   Simple GUI to start and stop the bot.
 *   Automatically resizes the game window to **1280x720** when the bot starts.
-*   Can zoom out after sending a march, or when skipping an unavailable deposit, by a configurable number of mouse wheel clicks.
+*   Can zoom out after sending a march (in two steps with a short pause) or when skipping an unavailable deposit. Each step uses a configurable number of mouse wheel clicks.
 
 ## Setup
 
@@ -57,7 +57,7 @@ Alternatively, launch the GUI:
     ```
     The GUI allows you to adjust the confidence level for detecting gem icons,
     tweak how the bot moves across the map, set how many mouse wheel clicks
-    the bot uses when zooming out, and adjust how long the bot waits after
+    the bot uses for each zoom-out step, and adjust how long the bot waits after
     dispatching troops. These values are passed to the bot as command
     line arguments when you click **Start Bot**.
 3.  **Initial Countdown:** The script has a 5-second countdown before it starts interacting. Use this time to switch to the game window and ensure it's in focus.
@@ -74,7 +74,8 @@ The main configuration variables are located at the top of the `rok_bot/gem_farm
 *   `ORANGE_MARCH_BUTTON_TEMPLATE`: Path to the image for the special orange march button that might indicate a full farming queue (default: `images/orange_march_button.png`).
 *   `ORANGE_MARCH_WAIT_SECONDS`: Duration (in seconds) to wait if the orange march button is detected (default: `1800`, i.e., 30 minutes).
 *   `DEBUG_TAKE_SCREENSHOT_AFTER_FIRST_CLICK`, `DEBUG_TAKE_SCREENSHOT_IF_GATHER_FAILS`: Set to `True` or `False` to enable/disable debug screenshots. Screenshots are saved in the `rok_bot/debug_screenshots` directory.
-*   `ZOOM_OUT_CLICKS_AFTER_MARCH`: Number of mouse wheel clicks used to zoom out after sending a march.
+*   `ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST` and `ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND`: Mouse wheel clicks used for the first and second zoom-out steps after sending a march.
+*   `ZOOM_OUT_DELAY_BETWEEN`: Delay in seconds between the two zoom-out steps (default: `0.1`).
 
 ### Systematic Search (Snake Pattern) Configuration:
 The bot now uses a 'snake' or boustrophedon pattern for map exploration.

--- a/rok_bot/gem_farmer.py
+++ b/rok_bot/gem_farmer.py
@@ -86,8 +86,12 @@ SNAKE_SCROLL_SEGMENT_DURATION = 2.0 # Seconds to scroll for each segment of a ho
 SYSTEMATIC_SCAN_PAUSE_IF_NO_GEM = 0.5
 
 # Zoom configuration
-# Number of mouse wheel clicks to perform after successfully dispatching a march
-ZOOM_OUT_CLICKS_AFTER_MARCH = 0
+# Two-step zoom out after dispatching a march
+# These represent the number of mouse wheel clicks for each step.
+ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST = 0
+ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND = 0
+# Delay between the two zoom actions (seconds)
+ZOOM_OUT_DELAY_BETWEEN = 0.1
 
 # Create screenshot directory
 # Adjusted to be relative to the script's location
@@ -146,10 +150,16 @@ def parse_args():
         help="Pause after a scan if no gem is found",
     )
     parser.add_argument(
-        "--zoom-out-clicks",
+        "--zoom-out-clicks-first",
         type=int,
-        default=ZOOM_OUT_CLICKS_AFTER_MARCH,
-        help="Mouse wheel clicks to zoom out after dispatching a march",
+        default=ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST,
+        help="Mouse wheel clicks for the first zoom-out after dispatching a march",
+    )
+    parser.add_argument(
+        "--zoom-out-clicks-second",
+        type=int,
+        default=ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND,
+        help="Mouse wheel clicks for the second zoom-out after dispatching a march",
     )
     parser.add_argument(
         "--farming-duration",
@@ -373,11 +383,18 @@ def record_dispatched(location_box):
 
 
 def zoom_out_after_dispatch():
-    """Zoom out the map slightly after a successful dispatch."""
-    if ZOOM_OUT_CLICKS_AFTER_MARCH > 0:
-        print(f"Zooming out {ZOOM_OUT_CLICKS_AFTER_MARCH} wheel clicks after dispatch...")
-        pyautogui.scroll(-ZOOM_OUT_CLICKS_AFTER_MARCH)
-        time.sleep(0.2)
+    """Zoom out the map in two steps after a successful dispatch."""
+    if ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST > 0:
+        print(
+            f"Zooming out {ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST} wheel clicks (step 1) after dispatch..."
+        )
+        pyautogui.scroll(-ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST)
+        time.sleep(ZOOM_OUT_DELAY_BETWEEN)
+    if ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND > 0:
+        print(
+            f"Zooming out {ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND} wheel clicks (step 2) after dispatch..."
+        )
+        pyautogui.scroll(-ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND)
 
 
 def is_deposit_gathered_on_map(location_box, margin=30):
@@ -676,7 +693,8 @@ if __name__ == "__main__":
     SNAKE_SCROLL_SEGMENT_DURATION = args.scroll_duration
     SNAKE_SCANS_PER_HORIZONTAL_PASS = args.scans_per_pass
     SYSTEMATIC_SCAN_PAUSE_IF_NO_GEM = args.pause_no_gem
-    ZOOM_OUT_CLICKS_AFTER_MARCH = args.zoom_out_clicks
+    ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST = args.zoom_out_clicks_first
+    ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND = args.zoom_out_clicks_second
     FARMING_DURATION_SECONDS = args.farming_duration
 
     main_bot_loop()

--- a/rok_bot/gui.py
+++ b/rok_bot/gui.py
@@ -9,7 +9,8 @@ DEFAULT_CONFIDENCE = 0.8
 DEFAULT_SCROLL_DURATION = 2.0
 DEFAULT_SCANS_PER_PASS = 5
 DEFAULT_PAUSE_NO_GEM = 0.5
-DEFAULT_ZOOM_CLICKS = 0
+DEFAULT_ZOOM_CLICKS_FIRST = 0
+DEFAULT_ZOOM_CLICKS_SECOND = 0
 DEFAULT_FARMING_DURATION = 300
 
 bot_process = None
@@ -29,7 +30,8 @@ def start_bot():
                 '--scroll-duration', str(scroll_duration_var.get()),
                 '--scans-per-pass', str(scans_var.get()),
                 '--pause-no-gem', str(pause_var.get()),
-                '--zoom-out-clicks', str(zoom_var.get()),
+                '--zoom-out-clicks-first', str(zoom_first_var.get()),
+                '--zoom-out-clicks-second', str(zoom_second_var.get()),
                 '--farming-duration', str(farming_duration_var.get()),
             ])
             status_var.set('Bot running')
@@ -89,13 +91,16 @@ ttk.Label(options, text='Pause if no gem (s):').grid(row=3, column=0, sticky='w'
 pause_var = tk.DoubleVar(value=DEFAULT_PAUSE_NO_GEM)
 ttk.Entry(options, textvariable=pause_var, width=6).grid(row=3, column=1, sticky='w')
 
-ttk.Label(options, text='Zoom out clicks after march:').grid(row=4, column=0, sticky='w')
-zoom_var = tk.IntVar(value=DEFAULT_ZOOM_CLICKS)
-ttk.Entry(options, textvariable=zoom_var, width=6).grid(row=4, column=1, sticky='w')
+ttk.Label(options, text='Zoom out clicks after march (step 1):').grid(row=4, column=0, sticky='w')
+zoom_first_var = tk.IntVar(value=DEFAULT_ZOOM_CLICKS_FIRST)
+ttk.Entry(options, textvariable=zoom_first_var, width=6).grid(row=4, column=1, sticky='w')
 
-ttk.Label(options, text='Farming wait after dispatch (s):').grid(row=5, column=0, sticky='w')
+ttk.Label(options, text='Zoom out clicks after march (step 2):').grid(row=5, column=0, sticky='w')
+zoom_second_var = tk.IntVar(value=DEFAULT_ZOOM_CLICKS_SECOND)
+ttk.Entry(options, textvariable=zoom_second_var, width=6).grid(row=5, column=1, sticky='w')
+ttk.Label(options, text='Farming wait after dispatch (s):').grid(row=6, column=0, sticky='w')
 farming_duration_var = tk.IntVar(value=DEFAULT_FARMING_DURATION)
-ttk.Entry(options, textvariable=farming_duration_var, width=6).grid(row=5, column=1, sticky='w')
+ttk.Entry(options, textvariable=farming_duration_var, width=6).grid(row=6, column=1, sticky='w')
 
 start_button = ttk.Button(frame, text='Start Bot', command=start_bot)
 start_button.grid(row=0, column=0, padx=5, pady=5)


### PR DESCRIPTION
## Summary
- allow two-step zoom after dispatch with configurable clicks
- add new CLI arguments for both zoom steps
- update GUI to expose the new settings
- document new zoom behaviour and settings

## Testing
- `python -m py_compile rok_bot/gem_farmer.py rok_bot/gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6841d2939cfc832d866115cfd9b64dbe