### PR TITLE
Add fifth zoom-out step and improve gem reuse check

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Python script uses `pyautogui` to automate the process of finding and farmi
 *   Debug options, including taking screenshots on certain events (e.g., after initial click, if gather fails).
 *   Simple GUI to start and stop the bot.
 *   Automatically resizes the game window to **1280x720** when the bot starts.
-*   Can zoom out after sending a march (in up to four steps with short pauses) or when skipping an unavailable deposit. Each step uses a configurable number of mouse wheel clicks.
+*   Can zoom out after sending a march (in up to five steps with short pauses) or when skipping an unavailable deposit. Each step uses a configurable number of mouse wheel clicks.
 *   Recognizes `troop_back.png` to quickly dispatch troops with a right-click on the next gem found.
 
 ## Setup
@@ -59,7 +59,7 @@ Alternatively, launch the GUI:
     ```
     The GUI allows you to adjust the confidence level for detecting gem icons,
     tweak how the bot moves across the map, set how many mouse wheel clicks
-    the bot uses for each of up to three zoom-out steps, and adjust how long the bot waits after
+    the bot uses for each of up to five zoom-out steps, and adjust how long the bot waits after
     dispatching troops. These values are passed to the bot as command
     line arguments when you click **Start Bot**.
 3.  **Initial Countdown:** The script has a 5-second countdown before it starts interacting. Use this time to switch to the game window and ensure it's in focus.
@@ -76,7 +76,7 @@ The main configuration variables are located at the top of the `rok_bot/gem_farm
 *   `ORANGE_MARCH_BUTTON_TEMPLATE`: Path to the image for the special orange march button that might indicate a full farming queue (default: `images/orange_march_button.png`).
 *   `ORANGE_MARCH_WAIT_SECONDS`: Duration (in seconds) to wait if the orange march button is detected (default: `1800`, i.e., 30 minutes).
 *   `DEBUG_TAKE_SCREENSHOT_AFTER_FIRST_CLICK`, `DEBUG_TAKE_SCREENSHOT_IF_GATHER_FAILS`: Set to `True` or `False` to enable/disable debug screenshots. Screenshots are saved in the `rok_bot/debug_screenshots` directory.
-*   `ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST`, `ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND`, `ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD`, and `ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH`: Mouse wheel clicks used for each zoom-out step after sending a march.
+*   `ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST`, `ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND`, `ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD`, `ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH`, and `ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH`: Mouse wheel clicks used for each zoom-out step after sending a march.
 *   `ZOOM_OUT_DELAY_BETWEEN`: Delay in seconds between the zoom-out steps (default: `0.1`).
 
 ### Systematic Search (Snake Pattern) Configuration:

--- a/rok_bot/gem_farmer.py
+++ b/rok_bot/gem_farmer.py
@@ -64,7 +64,7 @@ TARGET_WINDOW_SIZE = (1280, 720)  # Width x Height for the game window
 
 # Track deposits that have already been targeted to prevent sending troops twice
 # to the same location within a session.
-DISPATCH_IGNORE_RADIUS = 40  # pixels
+DISPATCH_IGNORE_RADIUS = 80  # pixels
 DISPATCHED_LOCATIONS = []
 RIGHT_CLICK_NEXT_GEM = False
 
@@ -88,12 +88,13 @@ SNAKE_SCROLL_SEGMENT_DURATION = 2.0 # Seconds to scroll for each segment of a ho
 SYSTEMATIC_SCAN_PAUSE_IF_NO_GEM = 0.5
 
 # Zoom configuration
-# Up to three zoom-out steps after dispatching a march
+# Up to five zoom-out steps after dispatching a march
 # These represent the number of mouse wheel clicks for each step.
 ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST = 0
 ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND = 0
 ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD = 0
 ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH = 0
+ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH = 0
 # Delay between the zoom actions (seconds)
 ZOOM_OUT_DELAY_BETWEEN = 0.1
 
@@ -176,6 +177,12 @@ def parse_args():
         type=int,
         default=ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH,
         help="Mouse wheel clicks for the fourth zoom-out after dispatching a march",
+    )
+    parser.add_argument(
+        "--zoom-out-clicks-fifth",
+        type=int,
+        default=ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH,
+        help="Mouse wheel clicks for the fifth zoom-out after dispatching a march",
     )
     parser.add_argument(
         "--farming-duration",
@@ -416,7 +423,7 @@ def record_dispatched(location_box):
 
 
 def zoom_out_after_dispatch():
-    """Zoom out the map in up to four steps after a successful dispatch."""
+    """Zoom out the map in up to five steps after a successful dispatch."""
     if ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST > 0:
         print(
             f"Zooming out {ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST} wheel clicks (step 1) after dispatch..."
@@ -440,6 +447,12 @@ def zoom_out_after_dispatch():
             f"Zooming out {ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH} wheel clicks (step 4) after dispatch..."
         )
         pyautogui.scroll(-ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH)
+        time.sleep(ZOOM_OUT_DELAY_BETWEEN)
+    if ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH > 0:
+        print(
+            f"Zooming out {ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH} wheel clicks (step 5) after dispatch..."
+        )
+        pyautogui.scroll(-ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH)
 
 
 def perform_quick_gem_farming_cycle(initial_gem_location_box):
@@ -770,6 +783,7 @@ if __name__ == "__main__":
     ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND = args.zoom_out_clicks_second
     ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD = args.zoom_out_clicks_third
     ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH = args.zoom_out_clicks_fourth
+    ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH = args.zoom_out_clicks_fifth
     FARMING_DURATION_SECONDS = args.farming_duration
 
     main_bot_loop()

--- a/rok_bot/gui.py
+++ b/rok_bot/gui.py
@@ -12,6 +12,8 @@ DEFAULT_PAUSE_NO_GEM = 0.5
 DEFAULT_ZOOM_CLICKS_FIRST = 0
 DEFAULT_ZOOM_CLICKS_SECOND = 0
 DEFAULT_ZOOM_CLICKS_THIRD = 0
+DEFAULT_ZOOM_CLICKS_FOURTH = 0
+DEFAULT_ZOOM_CLICKS_FIFTH = 0
 DEFAULT_FARMING_DURATION = 300
 
 bot_process = None
@@ -34,6 +36,8 @@ def start_bot():
                 '--zoom-out-clicks-first', str(zoom_first_var.get()),
                 '--zoom-out-clicks-second', str(zoom_second_var.get()),
                 '--zoom-out-clicks-third', str(zoom_third_var.get()),
+                '--zoom-out-clicks-fourth', str(zoom_fourth_var.get()),
+                '--zoom-out-clicks-fifth', str(zoom_fifth_var.get()),
                 '--farming-duration', str(farming_duration_var.get()),
             ])
             status_var.set('Bot running')
@@ -100,12 +104,22 @@ ttk.Entry(options, textvariable=zoom_first_var, width=6).grid(row=4, column=1, s
 ttk.Label(options, text='Zoom out clicks after march (step 2):').grid(row=5, column=0, sticky='w')
 zoom_second_var = tk.IntVar(value=DEFAULT_ZOOM_CLICKS_SECOND)
 ttk.Entry(options, textvariable=zoom_second_var, width=6).grid(row=5, column=1, sticky='w')
+
 ttk.Label(options, text='Zoom out clicks after march (step 3):').grid(row=6, column=0, sticky='w')
 zoom_third_var = tk.IntVar(value=DEFAULT_ZOOM_CLICKS_THIRD)
 ttk.Entry(options, textvariable=zoom_third_var, width=6).grid(row=6, column=1, sticky='w')
-ttk.Label(options, text='Farming wait after dispatch (s):').grid(row=7, column=0, sticky='w')
+
+ttk.Label(options, text='Zoom out clicks after march (step 4):').grid(row=7, column=0, sticky='w')
+zoom_fourth_var = tk.IntVar(value=DEFAULT_ZOOM_CLICKS_FOURTH)
+ttk.Entry(options, textvariable=zoom_fourth_var, width=6).grid(row=7, column=1, sticky='w')
+
+ttk.Label(options, text='Zoom out clicks after march (step 5):').grid(row=8, column=0, sticky='w')
+zoom_fifth_var = tk.IntVar(value=DEFAULT_ZOOM_CLICKS_FIFTH)
+ttk.Entry(options, textvariable=zoom_fifth_var, width=6).grid(row=8, column=1, sticky='w')
+
+ttk.Label(options, text='Farming wait after dispatch (s):').grid(row=9, column=0, sticky='w')
 farming_duration_var = tk.IntVar(value=DEFAULT_FARMING_DURATION)
-ttk.Entry(options, textvariable=farming_duration_var, width=6).grid(row=7, column=1, sticky='w')
+ttk.Entry(options, textvariable=farming_duration_var, width=6).grid(row=9, column=1, sticky='w')
 
 start_button = ttk.Button(frame, text='Start Bot', command=start_bot)
 start_button.grid(row=0, column=0, padx=5, pady=5)


### PR DESCRIPTION
## Summary
- support up to five zoom out steps after marching
- widen duplicate-dispatch radius so the same gem isn't targeted again
- expose the new zoom options in the GUI
- document new options in README

## Testing
- `python -m py_compile rok_bot/gem_farmer.py rok_bot/gui.py`
- `python rok_bot/gem_farmer.py --help` *(fails: No module named 'pyautogui')*

------
https://chatgpt.com/codex/tasks/task_e_6841df4decfc832d9fb8601ab1b7c94e