### PR TITLE
Insert zoom-in step between zoom out phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The main configuration variables are located at the top of the `rok_bot/gem_farm
 *   `ORANGE_MARCH_WAIT_SECONDS`: Duration (in seconds) to wait if the orange march button is detected (default: `1800`, i.e., 30 minutes).
 *   `DEBUG_TAKE_SCREENSHOT_AFTER_FIRST_CLICK`, `DEBUG_TAKE_SCREENSHOT_IF_GATHER_FAILS`: Set to `True` or `False` to enable/disable debug screenshots. Screenshots are saved in the `rok_bot/debug_screenshots` directory.
 *   `ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST`, `ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND`, `ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD`, `ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH`, and `ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH`: Mouse wheel clicks used for each zoom-out step after sending a march.
+*   `ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH`: Mouse wheel clicks for a zoom-in step performed between the fourth and fifth zoom-out steps.
 *   `ZOOM_OUT_DELAY_BETWEEN`: Delay in seconds between the zoom-out steps (default: `0.1`).
 
 ### Systematic Search (Snake Pattern) Configuration:

--- a/rok_bot/gem_farmer.py
+++ b/rok_bot/gem_farmer.py
@@ -95,6 +95,8 @@ ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND = 0
 ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD = 0
 ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH = 0
 ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH = 0
+# Number of mouse wheel clicks to zoom in between the fourth and fifth zoom-out steps
+ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH = 0
 # Delay between the zoom actions (seconds)
 ZOOM_OUT_DELAY_BETWEEN = 0.1
 
@@ -177,6 +179,15 @@ def parse_args():
         type=int,
         default=ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH,
         help="Mouse wheel clicks for the fourth zoom-out after dispatching a march",
+    )
+    parser.add_argument(
+        "--zoom-in-clicks-between-fourth-and-fifth",
+        type=int,
+        default=ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH,
+        help=(
+            "Mouse wheel clicks for a zoom-in step between the fourth and fifth "
+            "zoom-out after dispatching a march"
+        ),
     )
     parser.add_argument(
         "--zoom-out-clicks-fifth",
@@ -447,6 +458,12 @@ def zoom_out_after_dispatch():
             f"Zooming out {ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH} wheel clicks (step 4) after dispatch..."
         )
         pyautogui.scroll(-ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH)
+        time.sleep(ZOOM_OUT_DELAY_BETWEEN)
+    if ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH > 0:
+        print(
+            f"Zooming in {ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH} wheel clicks between steps 4 and 5 after dispatch..."
+        )
+        pyautogui.scroll(ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH)
         time.sleep(ZOOM_OUT_DELAY_BETWEEN)
     if ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH > 0:
         print(
@@ -784,6 +801,7 @@ if __name__ == "__main__":
     ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD = args.zoom_out_clicks_third
     ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH = args.zoom_out_clicks_fourth
     ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH = args.zoom_out_clicks_fifth
+    ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH = args.zoom_in_clicks_between_fourth_and_fifth
     FARMING_DURATION_SECONDS = args.farming_duration
 
     main_bot_loop()


### PR DESCRIPTION
## Summary
- add config constant for zoom-in step between the fourth and fifth zoom-out
- parse command line flag for this zoom-in step and wire it through
- perform zoom-in between zoom-out steps in farming logic
- document the new setting in the README

## Testing
- `python -m py_compile rok_bot/gem_farmer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e276877c832d9dac9578a6a5a9d9