### PR TITLE
Add final zoom-in step after 5th zoom-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Python script uses `pyautogui` to automate the process of finding and farmi
 *   Debug options, including taking screenshots on certain events (e.g., after initial click, if gather fails).
 *   Simple GUI to start and stop the bot.
 *   Automatically resizes the game window to **1280x720** when the bot starts.
-*   Can zoom out after sending a march (in up to five steps with short pauses) or when skipping an unavailable deposit. Each step uses a configurable number of mouse wheel clicks.
+*   Can zoom out after sending a march (in up to five steps with short pauses) or when skipping an unavailable deposit. A zoom-in step can occur between the fourth and fifth zoom-out steps and another zoom-in after the final step. Each step uses a configurable number of mouse wheel clicks.
 *   Recognizes `troop_back.png` to quickly dispatch troops with a right-click on the next gem found.
 
 ## Setup
@@ -78,6 +78,7 @@ The main configuration variables are located at the top of the `rok_bot/gem_farm
 *   `DEBUG_TAKE_SCREENSHOT_AFTER_FIRST_CLICK`, `DEBUG_TAKE_SCREENSHOT_IF_GATHER_FAILS`: Set to `True` or `False` to enable/disable debug screenshots. Screenshots are saved in the `rok_bot/debug_screenshots` directory.
 *   `ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST`, `ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND`, `ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD`, `ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH`, and `ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH`: Mouse wheel clicks used for each zoom-out step after sending a march.
 *   `ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH`: Mouse wheel clicks for a zoom-in step performed between the fourth and fifth zoom-out steps.
+*   `ZOOM_IN_CLICKS_AFTER_FIFTH`: Mouse wheel clicks for a zoom-in step performed after the fifth zoom-out step.
 *   `ZOOM_OUT_DELAY_BETWEEN`: Delay in seconds between the zoom-out steps (default: `0.1`).
 
 ### Systematic Search (Snake Pattern) Configuration:

--- a/rok_bot/gem_farmer.py
+++ b/rok_bot/gem_farmer.py
@@ -97,6 +97,8 @@ ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH = 0
 ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH = 0
 # Number of mouse wheel clicks to zoom in between the fourth and fifth zoom-out steps
 ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH = 0
+# Number of mouse wheel clicks to zoom in after the fifth zoom-out step
+ZOOM_IN_CLICKS_AFTER_FIFTH = 0
 # Delay between the zoom actions (seconds)
 ZOOM_OUT_DELAY_BETWEEN = 0.1
 
@@ -194,6 +196,12 @@ def parse_args():
         type=int,
         default=ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH,
         help="Mouse wheel clicks for the fifth zoom-out after dispatching a march",
+    )
+    parser.add_argument(
+        "--zoom-in-clicks-after-fifth",
+        type=int,
+        default=ZOOM_IN_CLICKS_AFTER_FIFTH,
+        help="Mouse wheel clicks for a final zoom-in after the fifth zoom-out step",
     )
     parser.add_argument(
         "--farming-duration",
@@ -470,7 +478,13 @@ def zoom_out_after_dispatch():
             f"Zooming out {ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH} wheel clicks (step 5) after dispatch..."
         )
         pyautogui.scroll(-ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH)
-
+        time.sleep(ZOOM_OUT_DELAY_BETWEEN)
+    if ZOOM_IN_CLICKS_AFTER_FIFTH > 0:
+        print(
+            f"Zooming in {ZOOM_IN_CLICKS_AFTER_FIFTH} wheel clicks after step 5..."
+        )
+        pyautogui.scroll(ZOOM_IN_CLICKS_AFTER_FIFTH)
+        
 
 def perform_quick_gem_farming_cycle(initial_gem_location_box):
     """Farm a gem deposit using a single right-click."""
@@ -802,6 +816,7 @@ if __name__ == "__main__":
     ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH = args.zoom_out_clicks_fourth
     ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH = args.zoom_out_clicks_fifth
     ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH = args.zoom_in_clicks_between_fourth_and_fifth
+    ZOOM_IN_CLICKS_AFTER_FIFTH = args.zoom_in_clicks_after_fifth
     FARMING_DURATION_SECONDS = args.farming_duration
 
     main_bot_loop()


### PR DESCRIPTION
## Summary
- allow configuration for a zoom-in action after the fifth zoom-out
- document the new option in README

## Testing
- `python -m py_compile rok_bot/gem_farmer.py`
- `python -m py_compile rok_bot/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6841e426df6c832d8f6c694cf0dfcac0