### PR TITLE
Add bottom navigation after zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Python script uses `pyautogui` to automate the process of finding and farmi
 *   Debug options, including taking screenshots on certain events (e.g., after initial click, if gather fails).
 *   Simple GUI to start and stop the bot.
 *   Automatically resizes the game window to **1280x720** when the bot starts.
-*   Can zoom out after sending a march (in up to five steps with short pauses) or when skipping an unavailable deposit. A zoom-in step can occur between the fourth and fifth zoom-out steps and another zoom-in after the final step. Each step uses a configurable number of mouse wheel clicks.
+*   Can zoom out after sending a march (in up to five steps with short pauses) or when skipping an unavailable deposit. A single zoom-in step occurs between the fourth and fifth zoom-out steps, and the bot then moves the view downward for a configurable duration.
 *   Recognizes `troop_back.png` to quickly dispatch troops with a right-click on the next gem found.
 
 ## Setup
@@ -77,8 +77,8 @@ The main configuration variables are located at the top of the `rok_bot/gem_farm
 *   `ORANGE_MARCH_WAIT_SECONDS`: Duration (in seconds) to wait if the orange march button is detected (default: `1800`, i.e., 30 minutes).
 *   `DEBUG_TAKE_SCREENSHOT_AFTER_FIRST_CLICK`, `DEBUG_TAKE_SCREENSHOT_IF_GATHER_FAILS`: Set to `True` or `False` to enable/disable debug screenshots. Screenshots are saved in the `rok_bot/debug_screenshots` directory.
 *   `ZOOM_OUT_CLICKS_AFTER_MARCH_FIRST`, `ZOOM_OUT_CLICKS_AFTER_MARCH_SECOND`, `ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD`, `ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH`, and `ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH`: Mouse wheel clicks used for each zoom-out step after sending a march.
-*   `ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH`: Mouse wheel clicks for a zoom-in step performed between the fourth and fifth zoom-out steps.
-*   `ZOOM_IN_CLICKS_AFTER_FIFTH`: Mouse wheel clicks for a zoom-in step performed after the fifth zoom-out step.
+*   `ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH`: Mouse wheel clicks for the zoom-in step between the fourth and fifth zoom-out steps (fixed at `1`).
+*   `DOWN_AFTER_ZOOM_DURATION`: How long to press the down navigation key after the zoom-out sequence completes.
 *   `ZOOM_OUT_DELAY_BETWEEN`: Delay in seconds between the zoom-out steps (default: `0.1`).
 
 ### Systematic Search (Snake Pattern) Configuration:

--- a/rok_bot/gem_farmer.py
+++ b/rok_bot/gem_farmer.py
@@ -96,9 +96,10 @@ ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD = 0
 ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH = 0
 ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH = 0
 # Number of mouse wheel clicks to zoom in between the fourth and fifth zoom-out steps
-ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH = 0
-# Number of mouse wheel clicks to zoom in after the fifth zoom-out step
-ZOOM_IN_CLICKS_AFTER_FIFTH = 0
+# This value is fixed and not user-configurable via the CLI or GUI
+ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH = 1
+# Duration (in seconds) to hold the down navigation key after completing the zoom-out steps
+DOWN_AFTER_ZOOM_DURATION = 1.0
 # Delay between the zoom actions (seconds)
 ZOOM_OUT_DELAY_BETWEEN = 0.1
 
@@ -183,25 +184,16 @@ def parse_args():
         help="Mouse wheel clicks for the fourth zoom-out after dispatching a march",
     )
     parser.add_argument(
-        "--zoom-in-clicks-between-fourth-and-fifth",
-        type=int,
-        default=ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH,
-        help=(
-            "Mouse wheel clicks for a zoom-in step between the fourth and fifth "
-            "zoom-out after dispatching a march"
-        ),
-    )
-    parser.add_argument(
         "--zoom-out-clicks-fifth",
         type=int,
         default=ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH,
         help="Mouse wheel clicks for the fifth zoom-out after dispatching a march",
     )
     parser.add_argument(
-        "--zoom-in-clicks-after-fifth",
-        type=int,
-        default=ZOOM_IN_CLICKS_AFTER_FIFTH,
-        help="Mouse wheel clicks for a final zoom-in after the fifth zoom-out step",
+        "--down-after-zoom-duration",
+        type=float,
+        default=DOWN_AFTER_ZOOM_DURATION,
+        help="Duration in seconds to press the down key after zooming out",
     )
     parser.add_argument(
         "--farming-duration",
@@ -479,11 +471,14 @@ def zoom_out_after_dispatch():
         )
         pyautogui.scroll(-ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH)
         time.sleep(ZOOM_OUT_DELAY_BETWEEN)
-    if ZOOM_IN_CLICKS_AFTER_FIFTH > 0:
+
+    if DOWN_AFTER_ZOOM_DURATION > 0:
         print(
-            f"Zooming in {ZOOM_IN_CLICKS_AFTER_FIFTH} wheel clicks after step 5..."
+            f"Navigating down for {DOWN_AFTER_ZOOM_DURATION}s after zoom-out..."
         )
-        pyautogui.scroll(ZOOM_IN_CLICKS_AFTER_FIFTH)
+        pyautogui.keyDown(SNAKE_VERTICAL_SCROLL_KEY)
+        time.sleep(DOWN_AFTER_ZOOM_DURATION)
+        pyautogui.keyUp(SNAKE_VERTICAL_SCROLL_KEY)
         
 
 def perform_quick_gem_farming_cycle(initial_gem_location_box):
@@ -815,8 +810,7 @@ if __name__ == "__main__":
     ZOOM_OUT_CLICKS_AFTER_MARCH_THIRD = args.zoom_out_clicks_third
     ZOOM_OUT_CLICKS_AFTER_MARCH_FOURTH = args.zoom_out_clicks_fourth
     ZOOM_OUT_CLICKS_AFTER_MARCH_FIFTH = args.zoom_out_clicks_fifth
-    ZOOM_IN_CLICKS_BETWEEN_FOURTH_AND_FIFTH = args.zoom_in_clicks_between_fourth_and_fifth
-    ZOOM_IN_CLICKS_AFTER_FIFTH = args.zoom_in_clicks_after_fifth
+    DOWN_AFTER_ZOOM_DURATION = args.down_after_zoom_duration
     FARMING_DURATION_SECONDS = args.farming_duration
 
     main_bot_loop()

--- a/rok_bot/gui.py
+++ b/rok_bot/gui.py
@@ -14,6 +14,7 @@ DEFAULT_ZOOM_CLICKS_SECOND = 0
 DEFAULT_ZOOM_CLICKS_THIRD = 0
 DEFAULT_ZOOM_CLICKS_FOURTH = 0
 DEFAULT_ZOOM_CLICKS_FIFTH = 0
+DEFAULT_DOWN_AFTER_ZOOM = 1.0
 DEFAULT_FARMING_DURATION = 300
 
 bot_process = None
@@ -38,6 +39,7 @@ def start_bot():
                 '--zoom-out-clicks-third', str(zoom_third_var.get()),
                 '--zoom-out-clicks-fourth', str(zoom_fourth_var.get()),
                 '--zoom-out-clicks-fifth', str(zoom_fifth_var.get()),
+                '--down-after-zoom-duration', str(down_after_zoom_var.get()),
                 '--farming-duration', str(farming_duration_var.get()),
             ])
             status_var.set('Bot running')
@@ -120,6 +122,10 @@ ttk.Entry(options, textvariable=zoom_fifth_var, width=6).grid(row=8, column=1, s
 ttk.Label(options, text='Farming wait after dispatch (s):').grid(row=9, column=0, sticky='w')
 farming_duration_var = tk.IntVar(value=DEFAULT_FARMING_DURATION)
 ttk.Entry(options, textvariable=farming_duration_var, width=6).grid(row=9, column=1, sticky='w')
+
+ttk.Label(options, text='Down key duration after zoom-out (s):').grid(row=10, column=0, sticky='w')
+down_after_zoom_var = tk.DoubleVar(value=DEFAULT_DOWN_AFTER_ZOOM)
+ttk.Entry(options, textvariable=down_after_zoom_var, width=6).grid(row=10, column=1, sticky='w')
 
 start_button = ttk.Button(frame, text='Start Bot', command=start_bot)
 start_button.grid(row=0, column=0, padx=5, pady=5)


### PR DESCRIPTION
## Summary
- always move down after zooming out and let GUI tweak the duration
- remove zoom-in customization and fix the zoom-in step at one click
- drop zoom-in after fifth step
- document the new setting

## Testing
- `python -m py_compile rok_bot/gem_farmer.py rok_bot/gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6841e7ffaba4832db302220b87732ad8